### PR TITLE
Fix for photo load error causing module to stop loading photos

### DIFF
--- a/MMM-RandomPhoto.js
+++ b/MMM-RandomPhoto.js
@@ -37,11 +37,12 @@ Module.register("MMM-RandomPhoto",{
 				}, self.config.animationSpeed, function() {
 					$(this).attr('id', 'mmm-photos-placeholder1');
 				});
-
-				setTimeout(function() {
-					self.load();
-				}, (self.config.updateInterval * 1000));
 		});
+
+		setTimeout(function() {
+			self.load();
+		}, (self.config.updateInterval * 1000));
+		
 	},
 
 	getDom: function() {


### PR DESCRIPTION
Moved the timeout out of the onload event scope.  If for some reason the photo does not load the timeout is never created, and therefore, does not load another photo.  With it moved the timeout is created whether or not the photo loads, and keep the module running.